### PR TITLE
escape open square brackets

### DIFF
--- a/TeamCity.ServiceMessages.Tests/src/Read/ServiceMessageParserTest.cs
+++ b/TeamCity.ServiceMessages.Tests/src/Read/ServiceMessageParserTest.cs
@@ -290,7 +290,7 @@ namespace JetBrains.TeamCity.ServiceMessages.Tests.Read
     [Test]
     public void ShouldParseService_simpleMessage_decode()
     {
-      var sr = new StringWrapper("##teamcity[name '\"|'|n|r|x|l|p||[|]']");
+      var sr = new StringWrapper("##teamcity[name '\"|'|n|r|x|l|p|||[|]']");
       var result = new ServiceMessageParser().ParseServiceMessages(sr).ToArray();
       Assert.AreEqual(1, result.Length);
 
@@ -427,7 +427,7 @@ namespace JetBrains.TeamCity.ServiceMessages.Tests.Read
     [Test]
     public void ShouldParseService_complexMessage_escaping()
     {
-      var sr = new StringWrapper("##teamcity[name    a='1\"|'|n|r|x|l|p||[|]'     b='2\"|'|n|r|x|l|p||[|]'   ]");
+      var sr = new StringWrapper("##teamcity[name    a='1\"|'|n|r|x|l|p|||[|]'     b='2\"|'|n|r|x|l|p|||[|]'   ]");
       var result = new ServiceMessageParser().ParseServiceMessages(sr).ToArray();
       Assert.AreEqual(1, result.Length);
 
@@ -443,7 +443,7 @@ namespace JetBrains.TeamCity.ServiceMessages.Tests.Read
     [Test]
     public void ShouldParseString()
     {
-      var result = new ServiceMessageParser().ParseServiceMessages("##teamcity[name    a='1\"|'|n|r|x|l|p||[|]'     b='2\"|'|n|r|x|l|p||[|]'   ]").ToArray();
+      var result = new ServiceMessageParser().ParseServiceMessages("##teamcity[name    a='1\"|'|n|r|x|l|p|||[|]'     b='2\"|'|n|r|x|l|p|||[|]'   ]").ToArray();
       Assert.AreEqual(1, result.Length);
 
       var msg = result[0];

--- a/TeamCity.ServiceMessages.Tests/src/Write/ServiceMessageFormatterTest.cs
+++ b/TeamCity.ServiceMessages.Tests/src/Write/ServiceMessageFormatterTest.cs
@@ -67,7 +67,7 @@ namespace JetBrains.TeamCity.ServiceMessages.Tests.Write
     public void SupportEscaping()
     {
       Assert.AreEqual(
-        "##teamcity[rulez Attribute='\" |' |n |r |x |l |p || [ |]']",
+        "##teamcity[rulez Attribute='\" |' |n |r |x |l |p || |[ |]']",
         new ServiceMessageFormatter().FormatMessage("rulez", new
                                                          {
                                                            Attribute = "\" ' \n \r \u0085 \u2028 \u2029 | [ ]",

--- a/TeamCity.ServiceMessages/src/ServiceMessageReplacements.cs
+++ b/TeamCity.ServiceMessages/src/ServiceMessageReplacements.cs
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-
-using System;
 using System.Text;
 using JetBrains.TeamCity.ServiceMessages.Annotations;
 
@@ -37,6 +35,7 @@ namespace JetBrains.TeamCity.ServiceMessages
           case '\''     : sb.Append("|'"); break;  //
           case '\n'     : sb.Append("|n"); break;  //
           case '\r'     : sb.Append("|r"); break;  //
+          case '['      : sb.Append("|["); break;  //
           case ']'      : sb.Append("|]"); break;  //
           case '\u0085' : sb.Append("|x"); break;  //\u0085 (next line)=>|x
           case '\u2028' : sb.Append("|l"); break;  //\u2028 (line separator)=>|l
@@ -73,6 +72,7 @@ namespace JetBrains.TeamCity.ServiceMessages
             case '\'': sb[i++] = ('\''); break;  //
             case 'n': sb[i++] = ('\n'); break;  //
             case 'r': sb[i++] = ('\r'); break;  //
+            case '[': sb[i++] = ('['); break;  //
             case ']': sb[i++] = (']'); break;  //
             case 'x': sb[i++] = ('\u0085'); break; //\u0085 (next line)=>|x
             case 'l': sb[i++] = ('\u2028'); break;//\u2028 (line separator)=>|l


### PR DESCRIPTION
Fix teamcity warning for messages like:

```
[Step 4/4] ##teamcity[message text='The [Entity|] |'this is a test|' was inserted!' status='NORMAL' timestamp='2013-02-13T21:50:04.017+0000' flowId='262144']
[Step 4/4] Incorrect property name.
Valid property list format is (name( )*=( )*'escaped_value'( )*)* where escape simbol is "|"
```
