### PR TITLE
Improve exceptions on dispose

### DIFF
--- a/TeamCity.ServiceMessages/Write/Special/Impl/Writer/TeamCityTestSuiteBlock.cs
+++ b/TeamCity.ServiceMessages/Write/Special/Impl/Writer/TeamCityTestSuiteBlock.cs
@@ -108,7 +108,7 @@ namespace JetBrains.TeamCity.ServiceMessages.Write.Special.Impl.Writer
             {
                 throw new InvalidOperationException($"TeamCity.ServiceMessages: Expected all test writers to be disposed, but found {_childTestsOpened.Count}: [{string.Join(", ", _childTestsOpened.ToArray())}] were not.");
             }
-            
+
             _flows.Dispose();
         }
     }

--- a/TeamCity.ServiceMessages/Write/Special/Impl/Writer/TeamCityTestSuiteBlock.cs
+++ b/TeamCity.ServiceMessages/Write/Special/Impl/Writer/TeamCityTestSuiteBlock.cs
@@ -17,12 +17,13 @@
 namespace JetBrains.TeamCity.ServiceMessages.Write.Special.Impl.Writer
 {
     using System;
+    using System.Collections.Generic;
 
     public class TeamCityTestSuiteBlock : BaseDisposableWriter<IFlowServiceMessageProcessor>, ITeamCityTestsSubWriter, ISubWriter
     {
         private readonly TeamCityFlowWriter<ITeamCityTestsSubWriter> _flows;
-        private int _isChildSuiteOpened;
-        private int _isChildTestOpened;
+        private Stack<string> _childSuitesOpened = new Stack<string>();
+        private Stack<string> _childTestsOpened = new Stack<string>();
 
         public TeamCityTestSuiteBlock([NotNull] IFlowServiceMessageProcessor target, [NotNull] IDisposable disposableHandler)
             : base(target, disposableHandler)
@@ -37,14 +38,14 @@ namespace JetBrains.TeamCity.ServiceMessages.Write.Special.Impl.Writer
 
         public void AssertNoChildOpened()
         {
-            if (_isChildSuiteOpened != 0)
+            if (_childSuitesOpened.Count != 0)
             {
-                throw new InvalidOperationException("There is at least one child test suite opened");
+                throw new InvalidOperationException($"TeamCity.ServiceMessages: Expected no test suites open, but found {_childSuitesOpened.Count}: [{string.Join(", ", _childSuitesOpened.ToArray())}]");
             }
 
-            if (_isChildTestOpened != 0)
+            if (_childTestsOpened.Count != 0)
             {
-                throw new InvalidOperationException("There is at least one test suite opened");
+                throw new InvalidOperationException($"TeamCity.ServiceMessages: Expected no tests open, but found {_childTestsOpened.Count}: [{string.Join(", ", _childTestsOpened.ToArray())}]");
             }
 
             _flows.AssertNoChildOpened();
@@ -60,7 +61,7 @@ namespace JetBrains.TeamCity.ServiceMessages.Write.Special.Impl.Writer
         {
             if (suiteName == null) throw new ArgumentNullException(nameof(suiteName));
             AssertNoChildOpened();
-            _isChildSuiteOpened++;
+            _childSuitesOpened.Push(suiteName);
             PostMessage(new ServiceMessage("testSuiteStarted") {{"name", suiteName}});
 
             return new TeamCityTestSuiteBlock(
@@ -68,8 +69,16 @@ namespace JetBrains.TeamCity.ServiceMessages.Write.Special.Impl.Writer
                 new DisposableDelegate(() =>
                 {
                     PostMessage(new ServiceMessage("testSuiteFinished") {{"name", suiteName}});
-                    _isChildSuiteOpened--;
+                    var result = _childSuitesOpened.Pop();
+                    if (result != suiteName)
+                        PostWarning($"TeamCity.ServiceMessages: Unexpected order of dispose - expected suite {result} to be disposed, but {suiteName} was disposed instead");
                 }));
+        }
+
+        private void PostWarning(string text)
+        {
+            var msg = new ServiceMessage("message") {{"text", text}, {"status", "ERROR"}, {"tc:tags", "tc:parseServiceMessagesInside"}};
+            PostMessage(msg);
         }
 
         public ITeamCityTestWriter OpenTest(string testName)
@@ -77,24 +86,29 @@ namespace JetBrains.TeamCity.ServiceMessages.Write.Special.Impl.Writer
             if (testName == null) throw new ArgumentNullException(nameof(testName));
             AssertNoChildOpened();
 
-            _isChildTestOpened++;
-            var writer = new TeamCityTestWriter(myTarget, testName, new DisposableDelegate(() => { _isChildTestOpened--; }));
+            _childTestsOpened.Push(testName);
+            var writer = new TeamCityTestWriter(myTarget, testName, new DisposableDelegate(() =>
+            {
+                var result = _childTestsOpened.Pop();
+                if (result != testName)
+                    PostWarning($"TeamCity.ServiceMessages: Unexpected order of dispose - expected test {result} to be disposed, but {testName} was disposed instead");
+            }));
             writer.OpenTest();
             return writer;
         }
 
         protected override void DisposeImpl()
         {
-            if (_isChildTestOpened != 0)
+            if (_childSuitesOpened.Count != 0)
             {
-                throw new InvalidOperationException("Some child test writers were not disposed.");
+                throw new InvalidOperationException($"TeamCity.ServiceMessages: Expected all test suite writers to be disposed, but found {_childSuitesOpened.Count}: [{string.Join(", ", _childSuitesOpened.ToArray())}] were not.");
             }
 
-            if (_isChildSuiteOpened != 0)
+            if (_childTestsOpened.Count != 0)
             {
-                throw new InvalidOperationException("Some child test suite writers were not disposed.");
+                throw new InvalidOperationException($"TeamCity.ServiceMessages: Expected all test writers to be disposed, but found {_childTestsOpened.Count}: [{string.Join(", ", _childTestsOpened.ToArray())}] were not.");
             }
-
+            
             _flows.Dispose();
         }
     }


### PR DESCRIPTION

## the problem

We frequently see issues where the only stack trace we get is:
```
Some child test suite writers were not disposed.
System.InvalidOperationException
   at JetBrains.TeamCity.ServiceMessages.Write.Special.Impl.Writer.TeamCityTestSuiteBlock.DisposeImpl()
   at JetBrains.TeamCity.ServiceMessages.Write.Special.Impl.Writer.BaseDisposableWriter`1.Dispose()
   at JetBrains.TeamCity.ServiceMessages.Write.Special.Impl.TeamCityWriterImpl.Dispose()
   at Autofac.Core.Disposer.DisposeAsync(Boolean disposing)
   at Autofac.Core.Lifetime.LifetimeScope.DisposeAsync(Boolean disposing)
...
```

The message `Some child test suite writers were not disposed.` isn't very useful to diagnose the problem.

## the proposal

Now, we keep a stack for the child suites and tests, so that when something goes wrong, we have more information to diagnose.

It'd be great if this could be merged in, and then merged into [TeamCity.VSTest.TestAdapter](https://github.com/JetBrains/TeamCity.VSTest.TestAdapter).