### PR TITLE
Add WriteProgress and OpenProgress methods

### DIFF
--- a/TeamCity.ServiceMessages.Tests/Write/Specials/TeamCityBuildStatusWriterTest.cs
+++ b/TeamCity.ServiceMessages.Tests/Write/Specials/TeamCityBuildStatusWriterTest.cs
@@ -21,6 +21,12 @@ namespace JetBrains.TeamCity.ServiceMessages.Tests.Write.Specials
         }
 
         [Test]
+        public void TestBuildProblemWithoutIdentity()
+        {
+            DoTest(x => x.WriteBuildProblem("aaaa"), "##teamcity[buildProblem description='aaaa']");
+        }
+
+        [Test]
         public void TestBuildProblem()
         {
             DoTest(x => x.WriteBuildProblem("id5", "aaaa"), "##teamcity[buildProblem identity='id5' description='aaaa']");

--- a/TeamCity.ServiceMessages.Tests/Write/Specials/TeamCityProgressWriterTest.cs
+++ b/TeamCity.ServiceMessages.Tests/Write/Specials/TeamCityProgressWriterTest.cs
@@ -1,0 +1,29 @@
+namespace JetBrains.TeamCity.ServiceMessages.Tests.Write.Specials
+{
+    using NUnit.Framework;
+    using ServiceMessages.Write.Special;
+    using ServiceMessages.Write.Special.Impl.Writer;
+
+    [TestFixture]
+    public class TeamCityProgressWriterTest : TeamCityWriterBaseTest<ITeamCityProgressWriter>
+    {
+        protected override ITeamCityProgressWriter Create(IServiceMessageProcessor proc)
+        {
+            return new TeamCityProgressWriter(proc);
+        }
+
+        [Test]
+        public void TestProgressMessage()
+        {
+            DoTest(x => x.WriteProgress("aaaa"), "##teamcity[progressMessage 'aaaa']");
+        }
+
+        [Test]
+        public void OpenProgressBlock()
+        {
+            DoTest(x => x.OpenProgress("aaaa").Dispose(),
+                "##teamcity[progressStart 'aaaa']",
+                "##teamcity[progressFinish 'aaaa']");
+        }
+    }
+}

--- a/TeamCity.ServiceMessages/TeamCity.ServiceMessages.csproj
+++ b/TeamCity.ServiceMessages/TeamCity.ServiceMessages.csproj
@@ -12,7 +12,7 @@
     <GenerateAssemblyVersionAttribute>true</GenerateAssemblyVersionAttribute>
     <GenerateNeutralResourcesLanguageAttribute>true</GenerateNeutralResourcesLanguageAttribute>
 
-    <TargetFrameworks>netstandard1.3;net35;net40;net45;netcoreapp1.0;netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net35;net40;net45;netcoreapp1.0;netcoreapp2.0;netcoreapp3.0;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>TeamCity.ServiceMessages</AssemblyName>
     <PackageId>TeamCity.ServiceMessages</PackageId>
     <RootNamespace>JetBrains.TeamCity.ServiceMessages</RootNamespace>

--- a/TeamCity.ServiceMessages/Write/Special/ITeamCityBuildStatusWriter.cs
+++ b/TeamCity.ServiceMessages/Write/Special/ITeamCityBuildStatusWriter.cs
@@ -21,6 +21,12 @@ namespace JetBrains.TeamCity.ServiceMessages.Write.Special
         /// <summary>
         /// Generates build problem service message
         /// </summary>
+        /// <param name="description">problem message</param>
+        void WriteBuildProblem([NotNull] string description);
+
+        /// <summary>
+        /// Generates build problem service message
+        /// </summary>
         /// <param name="identity">problem unique identity, no more than 60 chars</param>
         /// <param name="description">problem message</param>
         void WriteBuildProblem([NotNull] string identity, [NotNull] string description);

--- a/TeamCity.ServiceMessages/Write/Special/ITeamCityFlowWriter.cs
+++ b/TeamCity.ServiceMessages/Write/Special/ITeamCityFlowWriter.cs
@@ -6,9 +6,9 @@ namespace JetBrains.TeamCity.ServiceMessages.Write.Special
 
     /// <summary>
     /// Starts another flowId reporting starting. This call would emmit
-    /// <pre>##teamcity[flowStarted flowId='%lt;new flow id>' parent='current flow id']</pre>
+    /// <pre>##teamcity[flowStarted flowId='&lt;new flow id>' parent='current flow id']</pre>
     /// and
-    /// <pre>##teamcity[flowFinished flowId='%lt;new flow id>']</pre>
+    /// <pre>##teamcity[flowFinished flowId='&lt;new flow id>']</pre>
     /// on writer dispose
     /// </summary>
     /// <remarks>

--- a/TeamCity.ServiceMessages/Write/Special/ITeamCityProgressWriter.cs
+++ b/TeamCity.ServiceMessages/Write/Special/ITeamCityProgressWriter.cs
@@ -1,0 +1,41 @@
+﻿namespace JetBrains.TeamCity.ServiceMessages.Write.Special
+{
+    using System;
+
+    /// <summary>
+    /// <para>
+    /// Use <see cref="WriteProgress"/> method to add progress message
+    /// <pre>
+    ///     ##teamcity[progressMessage '&lt;message text>' ]
+    /// </pre>
+    /// </para>
+    ///
+    /// <para>
+    /// Use <see cref="OpenProgress"/> method to add progress message
+    /// <pre>##teamcity[progressStart '&lt;message>']</pre>
+    /// and
+    /// <pre>##teamcity[progressFinish '&lt;message>']</pre>
+    /// on writer dispose.
+    /// </para>
+    /// <para>
+    /// http://confluence.jetbrains.net/display/TCD18/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ReportingMessagesForBuildLog
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// Implementation is not thread-safe. Create an instance for each thread instead.
+    /// </remarks>
+    public interface ITeamCityProgressWriter
+    {
+        /// <summary>
+        /// Writes normal message
+        /// </summary>
+        /// <param name="message">text</param>
+        void WriteProgress([NotNull] string message);
+
+        /// <summary>
+        /// Generates start flow message and returns disposable object to close flow
+        /// </summary>
+        /// <returns></returns>
+        IDisposable OpenProgress(string message);
+    }
+}

--- a/TeamCity.ServiceMessages/Write/Special/ITeamCityWriter.cs
+++ b/TeamCity.ServiceMessages/Write/Special/ITeamCityWriter.cs
@@ -13,7 +13,7 @@ namespace JetBrains.TeamCity.ServiceMessages.Write.Special
     /// <remarks>
     /// Implementation is not thread-safe. Create an instance for each thread instead.
     /// </remarks>
-    public interface ITeamCityWriter : ITeamCityBlockWriter<ITeamCityWriter>, ITeamCityFlowWriter<ITeamCityWriter>, ITeamCityMessageWriter, ITeamCityTestsWriter, ITeamCityCompilationBlockWriter<ITeamCityWriter>, ITeamCityArtifactsWriter, ITeamCityBuildStatusWriter, IDisposable
+    public interface ITeamCityWriter : ITeamCityBlockWriter<ITeamCityWriter>, ITeamCityFlowWriter<ITeamCityWriter>, ITeamCityMessageWriter, ITeamCityTestsWriter, ITeamCityCompilationBlockWriter<ITeamCityWriter>, ITeamCityArtifactsWriter, ITeamCityBuildStatusWriter, ITeamCityProgressWriter, IDisposable
     {
         /// <summary>
         /// Allows sending bare service message

--- a/TeamCity.ServiceMessages/Write/Special/Impl/TeamCityWriterFacade.cs
+++ b/TeamCity.ServiceMessages/Write/Special/Impl/TeamCityWriterFacade.cs
@@ -14,6 +14,7 @@ namespace JetBrains.TeamCity.ServiceMessages.Write.Special.Impl
         private readonly ITeamCityMessageWriter _messageWriter;
         private readonly IServiceMessageProcessor _processor;
         private readonly ITeamCityBuildStatusWriter _statusWriter;
+        private readonly ITeamCityProgressWriter _progressWriter;
         private readonly ITeamCityTestsWriter _testsWriter;
         private volatile bool _isDisposed;
 
@@ -26,6 +27,7 @@ namespace JetBrains.TeamCity.ServiceMessages.Write.Special.Impl
             [NotNull] ITeamCityArtifactsWriter artifactsWriter,
             [NotNull] ITeamCityBuildStatusWriter statusWriter,
             [NotNull] ITeamCityFlowWriter<ITeamCityWriter> flowWriter,
+            [NotNull] ITeamCityProgressWriter progressWriter,
             [NotNull] IDisposable disposeCallback)
         {
             if (processor == null) throw new ArgumentNullException(nameof(processor));
@@ -36,6 +38,7 @@ namespace JetBrains.TeamCity.ServiceMessages.Write.Special.Impl
             if (artifactsWriter == null) throw new ArgumentNullException(nameof(artifactsWriter));
             if (statusWriter == null) throw new ArgumentNullException(nameof(statusWriter));
             if (flowWriter == null) throw new ArgumentNullException(nameof(flowWriter));
+            if (progressWriter == null) throw new ArgumentNullException(nameof(progressWriter));
             if (disposeCallback == null) throw new ArgumentNullException(nameof(disposeCallback));
             _processor = processor;
             _blockWriter = blockWriter;
@@ -45,6 +48,7 @@ namespace JetBrains.TeamCity.ServiceMessages.Write.Special.Impl
             _artifactsWriter = artifactsWriter;
             _statusWriter = statusWriter;
             _flowWriter = flowWriter;
+            _progressWriter = progressWriter;
             _dispose = disposeCallback;
         }
 
@@ -59,6 +63,13 @@ namespace JetBrains.TeamCity.ServiceMessages.Write.Special.Impl
             if (buildNumber == null) throw new ArgumentNullException(nameof(buildNumber));
             CheckConsistency();
             _statusWriter.WriteBuildNumber(buildNumber);
+        }
+
+        public void WriteBuildProblem(string description)
+        {
+            if (description == null) throw new ArgumentNullException(nameof(description));
+            CheckConsistency();
+            _statusWriter.WriteBuildProblem(description);
         }
 
         public void WriteBuildProblem(string identity, string message)
@@ -104,6 +115,20 @@ namespace JetBrains.TeamCity.ServiceMessages.Write.Special.Impl
             if (text == null) throw new ArgumentNullException(nameof(text));
             CheckConsistency();
             _messageWriter.WriteError(text, errorDetails);
+        }
+
+        public void WriteProgress(string message)
+        {
+            if (message == null) throw new ArgumentNullException(nameof(message));
+            CheckConsistency();
+            _progressWriter.WriteProgress(message);
+        }
+
+        public IDisposable OpenProgress(string message)
+        {
+            if (message == null) throw new ArgumentNullException(nameof(message));
+            CheckConsistency();
+            return _progressWriter.OpenProgress(message);
         }
 
         public virtual void Dispose()

--- a/TeamCity.ServiceMessages/Write/Special/Impl/TeamCityWriterImpl.cs
+++ b/TeamCity.ServiceMessages/Write/Special/Impl/TeamCityWriterImpl.cs
@@ -21,6 +21,7 @@ namespace JetBrains.TeamCity.ServiceMessages.Write.Special.Impl
                 new TeamCityMessageWriter(processor),
                 new TeamCityArtifactsWriter(processor),
                 new TeamCityBuildStatusWriter(processor),
+                new TeamCityProgressWriter(processor),
                 dispose)
         {
             if (processor == null) throw new ArgumentNullException(nameof(processor));
@@ -36,8 +37,9 @@ namespace JetBrains.TeamCity.ServiceMessages.Write.Special.Impl
             [NotNull] ITeamCityMessageWriter messageWriter,
             [NotNull] ITeamCityArtifactsWriter artifactsWriter,
             [NotNull] ITeamCityBuildStatusWriter statusWriter,
+            [NotNull] ITeamCityProgressWriter progressWriter,
             [NotNull] IDisposable dispose)
-            : base(processor, blockWriter, compilationWriter, testsWriter, messageWriter, artifactsWriter, statusWriter, flowWriter, dispose)
+            : base(processor, blockWriter, compilationWriter, testsWriter, messageWriter, artifactsWriter, statusWriter, flowWriter,  progressWriter, dispose)
         {
             if (processor == null) throw new ArgumentNullException(nameof(processor));
             if (flowWriter == null) throw new ArgumentNullException(nameof(flowWriter));
@@ -47,6 +49,7 @@ namespace JetBrains.TeamCity.ServiceMessages.Write.Special.Impl
             if (messageWriter == null) throw new ArgumentNullException(nameof(messageWriter));
             if (artifactsWriter == null) throw new ArgumentNullException(nameof(artifactsWriter));
             if (statusWriter == null) throw new ArgumentNullException(nameof(statusWriter));
+            if (progressWriter == null) throw new ArgumentNullException(nameof(progressWriter));
             if (dispose == null) throw new ArgumentNullException(nameof(dispose));
             _writeCheck = new ISubWriter[] {blockWriter, compilationWriter, testsWriter, flowWriter};
         }

--- a/TeamCity.ServiceMessages/Write/Special/Impl/Writer/TeamCityBuildStatusWriter.cs
+++ b/TeamCity.ServiceMessages/Write/Special/Impl/Writer/TeamCityBuildStatusWriter.cs
@@ -18,6 +18,12 @@ namespace JetBrains.TeamCity.ServiceMessages.Write.Special.Impl.Writer
             PostMessage(new ValueServiceMessage("buildNumber", buildNumber));
         }
 
+        public void WriteBuildProblem(string description)
+        {
+            if (description == null) throw new ArgumentNullException(nameof(description));
+            PostMessage(new ServiceMessage("buildProblem") {{"description", description}});
+        }
+
         public void WriteBuildProblem(string identity, string message)
         {
             if (identity == null) throw new ArgumentNullException(nameof(identity));

--- a/TeamCity.ServiceMessages/Write/Special/Impl/Writer/TeamCityFlowWriter.cs
+++ b/TeamCity.ServiceMessages/Write/Special/Impl/Writer/TeamCityFlowWriter.cs
@@ -38,7 +38,7 @@ namespace JetBrains.TeamCity.ServiceMessages.Write.Special.Impl.Writer
                 processor
             );
 
-            //##teamcity[flowStarted flowId='%lt;new flow id>' parent='current flow id']
+            //##teamcity[flowStarted flowId='<new flow id>' parent='current flow id']
             var flowStartedMessage = new ServiceMessage("flowStarted");
             if (myTarget.FlowId != null)
             {
@@ -69,7 +69,7 @@ namespace JetBrains.TeamCity.ServiceMessages.Write.Special.Impl.Writer
 
             _openChildFlowIds.Remove(flowAwareServiceMessageProcessor.FlowId);
 
-            //##teamcity[flowFinished flowId='%lt;new flow id>']
+            //##teamcity[flowFinished flowId='<new flow id>']
             flowAwareServiceMessageProcessor.AddServiceMessage(new ServiceMessage("flowFinished"));
         }
     }

--- a/TeamCity.ServiceMessages/Write/Special/Impl/Writer/TeamCityProgressWriter.cs
+++ b/TeamCity.ServiceMessages/Write/Special/Impl/Writer/TeamCityProgressWriter.cs
@@ -1,0 +1,26 @@
+﻿namespace JetBrains.TeamCity.ServiceMessages.Write.Special.Impl.Writer
+{
+    using System;
+
+    public class TeamCityProgressWriter : BaseWriter, ITeamCityProgressWriter
+    {
+        public TeamCityProgressWriter(IServiceMessageProcessor target)
+            : base(target)
+        {
+            if (target == null) throw new ArgumentNullException(nameof(target));
+        }
+
+        public void WriteProgress(string message)
+        {
+            if (message == null) throw new ArgumentNullException(nameof(message));
+            PostMessage(new ValueServiceMessage("progressMessage", message));
+        }
+
+        public IDisposable OpenProgress(string message)
+        {
+            if (message == null) throw new ArgumentNullException(nameof(message));
+            PostMessage(new ValueServiceMessage("progressStart", message));
+            return new DisposableDelegate(() => PostMessage(new ValueServiceMessage("progressFinish", message)));
+        }
+    }
+}


### PR DESCRIPTION
Hi!

1. According to [build-script-interaction-with-teamcity.html#reporting-build-progress](https://www.jetbrains.com/help/teamcity/2018.1/build-script-interaction-with-teamcity.html#reporting-build-progress), there should be support of 

    ```
    ##teamcity[progressMessage '<message>']
    ```

    and 

    ```
    ##teamcity[progressStart '<message>']
    ...some build activity...
    ##teamcity[progressFinish '<message>']
    ```

    service messages.  This PR add this support.

2. Also I've noted that build targets somewhat obolete and I've added netstandard2.0, net6.0 and net8.0 targets.

3.  I've also notices that WriteBuildProblem has required parameter named `identity`, bu [documentation](https://www.jetbrains.com/help/teamcity/service-messages.html#Reporting+Build+Problems) says that `identity` should be optional:

    ```
    identity (optional): a unique problem ID. Different problems must have different identity, same problems — same identity, 
    which should not change throughout builds if the same problem, for example, the same compilation error occurs. It must be 
    a valid Java ID up to 60 characters. If omitted, the identity is calculated based on the description text.
    ```

    So, I've added additional method without `identity` parameter to not break compatibility with existing code

Please, review this PR.

Cheers, Aleksei.